### PR TITLE
Better matrix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,24 @@ Groovy Console is built into the Gradle file.
 
     ./gradlew console
 
+# Other development commands
+
+Generate code coverage reports.  Due to a [bug in cobertura code coverage][#39]
+is most reliable in Groovy versions 1.8.9 or 2.0.8.  See the final report in
+`build/reports/cobertura`.
+
+    GROOVY_VERSION=1.8.9 ./gradlew clean cobertura
+
+Build the jar file.
+
+    ./gradlew clean jar
+
+Sign build jars and sign archives.
+
+    ./gradlew clean check signArchives
+
+See also [RELEASE.md](RELEASE.md).
+
 # License
 
     Copyright 2014-2016 Sam Gleske
@@ -164,6 +182,7 @@ Groovy Console is built into the Gradle file.
     See the License for the specific language governing permissions and
     limitations under the License.
 
+[#39]: https://github.com/samrocketman/jervis/issues/39
 [jenkins-plugin-docker]: https://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin
 [jenkins-plugin-job-dsl]: https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin
 [jenkins]: https://jenkins-ci.org/

--- a/src/main/groovy/net/gleske/jervis/exceptions/ToolchainBadValueInKeyException.java
+++ b/src/main/groovy/net/gleske/jervis/exceptions/ToolchainBadValueInKeyException.java
@@ -1,0 +1,38 @@
+/*
+   Copyright 2014-2016 Sam Gleske - https://github.com/samrocketman/jervis
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   */
+package net.gleske.jervis.exceptions;
+
+/**
+  A type of <tt>{@link net.gleske.jervis.exceptions.ToolchainValidationException}</tt> which is thrown when there is a bad value in a toolchains file key.
+
+  <h2>Sample usage</h2>
+<pre><tt>import net.gleske.jervis.exceptions.ToolchainBadValueInKeyException
+throw new ToolchainBadValueInKeyException('some error')</tt></pre><br>
+ */
+public class ToolchainBadValueInKeyException extends ToolchainValidationException {
+
+    /**
+      Throw an exception for a bad value in a key.
+
+      @param message A simple message that will be prepended with <tt>'Bad value in
+                     key: ' + message</tt>.  This message is further wrapped by the
+                     message in
+                     <tt>{@link net.gleske.jervis.exceptions.ToolchainValidationException}</tt>.
+     */
+    public ToolchainBadValueInKeyException(String message) {
+        super("Bad value in key: " + message);
+    }
+}

--- a/src/main/groovy/net/gleske/jervis/exceptions/ToolchainMissingKeyException.java
+++ b/src/main/groovy/net/gleske/jervis/exceptions/ToolchainMissingKeyException.java
@@ -16,7 +16,7 @@
 package net.gleske.jervis.exceptions;
 
 /**
-  A type of <tt>{@link net.gleske.jervis.exceptions.ToolchainValidationException}</tt> which is thrown when a lifecycles file key is referenced but missing.
+  A type of <tt>{@link net.gleske.jervis.exceptions.ToolchainValidationException}</tt> which is thrown when a toolchains file key is referenced but missing.
 
   <h2>Sample usage</h2>
 <pre><tt>import net.gleske.jervis.exceptions.ToolchainMissingKeyException

--- a/src/main/groovy/net/gleske/jervis/lang/lifecycleGenerator.groovy
+++ b/src/main/groovy/net/gleske/jervis/lang/lifecycleGenerator.groovy
@@ -590,7 +590,7 @@ env:
                     jervis_yaml[toolchain] = jervis_yaml[toolchain].toString()
                 }
                 //toolchain must be an instance of String, List, or (in the case of only advanced toolchains) Map.
-                if(!isInstanceFromList(jervis_yaml[toolchain], [String, List]) && ((toolchain_obj.toolchainType(toolchain) == 'advanced') && !(jervis_yaml[toolchain] instanceof Map))) {
+                if(!isInstanceFromList(jervis_yaml[toolchain], [String, List]) && !((toolchain_obj.toolchainType(toolchain) == 'advanced') && (jervis_yaml[toolchain] instanceof Map))) {
                     throw new UnsupportedToolException("${toolchain}: ${jervis_yaml[toolchain]}")
                 }
                 if(jervis_yaml[toolchain] instanceof String) {

--- a/src/main/groovy/net/gleske/jervis/lang/lifecycleGenerator.groovy
+++ b/src/main/groovy/net/gleske/jervis/lang/lifecycleGenerator.groovy
@@ -88,6 +88,11 @@ class lifecycleGenerator {
     String[] yaml_keys
 
     /**
+      A variable for determining whether or not this is a matrix build.
+     */
+    Boolean matrix_build = false
+
+    /**
       A quick access variable for matrix build axes.
      */
     List yaml_matrix_axes
@@ -341,15 +346,20 @@ class lifecycleGenerator {
         //just load an empty file list by default initially that can then be overridden.
         this.setFolder_listing([])
         //configure the matrix axes if it is a matrix build i.e. set yaml_matrix_axes
-        if(this.isMatrixBuild()) {
-            yaml_matrix_axes = []
-            toolchain_obj.toolchains["toolchains"][yaml_language].each {
-                if((jervis_yaml[it] instanceof List) && (jervis_yaml[it].size() > 1)) {
+        matrix_build = false
+        yaml_matrix_axes = []
+        toolchain_obj.toolchains["toolchains"][yaml_language].each { toolchain ->
+            if(toolchain_obj.supportedMatrix(yaml_language, toolchain)) {
+                String matrix_type = toolchain_obj.toolchainType(toolchain)
+                if((matrix_type == 'simple') && (getObjectValue(jervis_yaml, toolchain, []).size() > 1)) {
+                    matrix_build = true
                     yaml_matrix_axes << it
                 }
-                else if((it == 'env') && (jervis_yaml[it] instanceof Map) && ('matrix' in jervis_yaml[it]) && (jervis_yaml[it]['matrix'].size() > 1)) {
+                else if((matrix_type == 'advanced') && (getObjectValue(jervis_yaml[toolchain],'matrix', []).size() > 1)) {
+                    matrix_build = true
                     yaml_matrix_axes << it
                 }
+                //else matrix_type == disabled
             }
         }
     }
@@ -365,7 +375,7 @@ env: foo=bar</tt></pre>
       <pre><tt>language: groovy
 env:
   - foo=bar</tt></pre>
-      <p>However, the following YAML will produce a matrix build.</p>
+      <p>However, the following YAML will produce a matrix build.  This assumes that <tt>matrix: disabled</tt> is not set for <tt>env</tt> in the <a href="https://github.com/samrocketman/jervis/wiki/Specification-for-toolchains-file" target="_blank">toolchains file</a>.</p>
       <pre><tt>language: groovy
 env:
   - foobar=foo
@@ -374,18 +384,7 @@ env:
       @return <tt>true</tt> if a matrix build will be generated or <tt>false</tt> if it will just be a regular build.
      */
     public Boolean isMatrixBuild() {
-        Boolean result=false
-        yaml_keys.each{
-            if(toolchain_obj.supportedMatrix(yaml_language, it)) {
-                if(jervis_yaml[it] instanceof List && jervis_yaml[it].size() > 1) {
-                     result=true
-                }
-                else if(('env' == it) && (jervis_yaml[it] instanceof Map) && ('matrix' in jervis_yaml[it]) && (jervis_yaml[it]['matrix'] instanceof List) && (jervis_yaml[it]['matrix'].size() > 1)) {
-                     result=true
-                }
-            }
-        }
-        return result
+        matrix_build
     }
 
     /*
@@ -555,15 +554,17 @@ env:
             output += 'esac\n'
         }
         else {
-            if(!toolchain_obj.supportedTool(toolchain, chain[0])) {
-                throw new UnsupportedToolException("${toolchain}: ${chain[0]}")
-            }
-            if(chain[0] in toolchain_keys) {
-                output += toolchain_obj.toolchains[toolchain][chain[0]].join('\n') + '\n'
-            }
-            else {
-                //assume using "*" key
-                output += this.interpolate_ivalue(toolchain_obj.toolchains[toolchain]['*'], chain[0].toString()).join('\n') + '\n'
+            chain.each {
+                if(!toolchain_obj.supportedTool(toolchain, it)) {
+                    throw new UnsupportedToolException("${toolchain}: ${it}")
+                }
+                if(it in toolchain_keys) {
+                    output += toolchain_obj.toolchains[toolchain][it].join('\n') + '\n'
+                }
+                else {
+                    //assume using "*" key
+                    output += this.interpolate_ivalue(toolchain_obj.toolchains[toolchain]['*'], it).join('\n') + '\n'
+                }
             }
         }
         return output
@@ -578,15 +579,18 @@ env:
         //get toolchain order for this language
         def toolchains_order = toolchain_obj.toolchains['toolchains'][yaml_language]
         String output = '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n'
-        toolchains_order.each {
-            def toolchain = it
+        toolchains_order.each { toolchain ->
             String[] toolchain_keys = toolchain_obj.toolchains[toolchain].keySet() as String[]
             output += "#${toolchain} toolchain section\n"
             if(toolchain in yaml_keys) {
-                //do non-default stuff
+                //User wants to override default with a toolchain value in their YAML file.
                 def user_toolchain
-                //toolchain must be an instance of String, List, or (in the case of only env) Map.
-                if(!(jervis_yaml[toolchain] instanceof String) && !(jervis_yaml[toolchain] instanceof List) && !(('env' == toolchain) && (jervis_yaml['env'] instanceof Map))) {
+                //convert doubles and integers to strings fixing bug #85
+                if(jervis_yaml[toolchain] instanceof Number) {
+                    jervis_yaml[toolchain] = jervis_yaml[toolchain].toString()
+                }
+                //toolchain must be an instance of String, List, or (in the case of only advanced toolchains) Map.
+                if(!isInstanceFromList(jervis_yaml[toolchain], [String, List]) && ((toolchain_obj.toolchainType(toolchain) == 'advanced') && !(jervis_yaml[toolchain] instanceof Map))) {
                     throw new UnsupportedToolException("${toolchain}: ${jervis_yaml[toolchain]}")
                 }
                 if(jervis_yaml[toolchain] instanceof String) {
@@ -595,70 +599,45 @@ env:
                 else {
                     user_toolchain = jervis_yaml[toolchain]
                 }
-                //check if a matrix build
-                if(toolchain in yaml_matrix_axes) {
-                    if(('env' == toolchain) && (user_toolchain instanceof Map)) {
-                        //special env behavior for global and matrix values
-                        def env = user_toolchain
-                        if('global' in env) {
-                            if(env['global'] instanceof String) {
-                                output += this.toolchainBuilder(toolchain, toolchain_keys, [env['global']], false)
-                            }
-                            else if(env['global'] instanceof List) {
-                                env['global'].each {
-                                    output += this.toolchainBuilder(toolchain, toolchain_keys, [it], false)
-                                }
-                            }
-                            else {
-                                throw new UnsupportedToolException("${toolchain}: global.${env['global']}")
-                            }
+                //check if a matrix toolchain
+                boolean matrix_toolchan = toolchain in yaml_matrix_axes
+                if(user_toolchain instanceof Map) {
+                    //because it is an instance of a Map we assume it is an advanced toolchain
+                    //special advanced behavior for global and matrix values
+                    if('global' in user_toolchain) {
+                        //convert doubles and integers to strings fixing bug #85
+                        if(user_toolchain['global'] instanceof Number) {
+                            user_toolchain['global'] = user_toolchain['global'].toString()
                         }
-                        if('matrix' in env) {
-                            if(env['matrix'] instanceof List) {
-                                output += this.toolchainBuilder(toolchain, toolchain_keys, env['matrix'], true)
-                            }
-                            else {
-                                throw new UnsupportedToolException("${toolchain}: matrix.${env['matrix']}")
-                            }
+                        if(user_toolchain['global'] instanceof String) {
+                            output += toolchainBuilder(toolchain, toolchain_keys, [user_toolchain['global']], false)
+                        }
+                        else if(user_toolchain['global'] instanceof List) {
+                            output += toolchainBuilder(toolchain, toolchain_keys, user_toolchain['global']*.toString(), false)
+                        }
+                        else {
+                            throw new UnsupportedToolException("${toolchain}: global.${user_toolchain['global']}")
                         }
                     }
-                    else {
-                        //normal toolchain behavior
-                        output += this.toolchainBuilder(toolchain, toolchain_keys, user_toolchain, true)
+                    if('matrix' in user_toolchain) {
+                        if(user_toolchain['matrix'] instanceof List) {
+                            output += this.toolchainBuilder(toolchain, toolchain_keys, user_toolchain['matrix'], matrix_toolchan)
+                        }
+                        else {
+                            throw new UnsupportedToolException("${toolchain}: matrix.${user_toolchain['matrix']}")
+                        }
                     }
                 }
+                else if(user_toolchain instanceof String) {
+                    output += this.toolchainBuilder(toolchain, toolchain_keys, [user_toolchain], matrix_toolchan)
+                }
                 else {
-                    //not a matrix build
-                    if(('env' == toolchain) && (user_toolchain instanceof Map)) {
-                        if('global' in user_toolchain) {
-                            if(user_toolchain['global'] instanceof String) {
-                                output += this.toolchainBuilder(toolchain, toolchain_keys, [user_toolchain['global']], false)
-                            }
-                            else if(user_toolchain['global'] instanceof List) {
-                                user_toolchain['global'].each {
-                                    output += this.toolchainBuilder(toolchain, toolchain_keys, [it], false)
-                                }
-                            }
-                            else {
-                                    throw new UnsupportedToolException("${toolchain}: global.${user_toolchain['global']}")
-                            }
-                        }
-                        if('matrix' in user_toolchain) {
-                            if(user_toolchain['matrix'] instanceof String) {
-                                output += this.toolchainBuilder(toolchain, toolchain_keys, [user_toolchain['matrix']], false)
-                            }
-                            else {
-                                output += this.toolchainBuilder(toolchain, toolchain_keys, user_toolchain['matrix'], false)
-                            }
-                        }
-                    }
-                    else {
-                        output += this.toolchainBuilder(toolchain, toolchain_keys, user_toolchain, false)
-                    }
+                    //normal simple toolchain behavior
+                    output += this.toolchainBuilder(toolchain, toolchain_keys, user_toolchain*.toString(), matrix_toolchan)
                 }
             }
             else {
-                //falling back to default behavior in toolchains.json
+                //falling back to default behavior in toolchains.json because user has not defined it in their YAML.
                 String default_ivalue = toolchain_obj.toolchains[toolchain].default_ivalue
                 if(default_ivalue) {
                     if(default_ivalue in toolchain_keys) {
@@ -796,7 +775,7 @@ env:
       @return Returns the value of the key or a <tt>defaultValue</tt> which is of the
               same type as <tt>defaultValue</tt>.
      */
-    public Object getObjectValue(Map object, String key, Object defaultValue) {
+    public static Object getObjectValue(Map object, String key, Object defaultValue) {
         if(key.indexOf('.') >= 0) {
             String key1 = key.split('\\.', 2)[0]
             String key2 = key.split('\\.', 2)[1]
@@ -823,6 +802,18 @@ env:
 
         //nothing worked so just return default value
         return defaultValue
+    }
+
+
+    /**
+      Check if an object is an instance of any of the classes in a list.
+      @param object Any kind of object.
+      @param list   A list of classes deriving from type Class.
+      @return       <tt>true</tt> if <tt>object</tt> is an instance of any one of the
+                    items in the <tt>list</tt>.
+     */
+    public static boolean isInstanceFromList(Object object, List<Class> list) {
+        true in list*.isInstance(object)
     }
 
     /**

--- a/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
+++ b/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
@@ -18,6 +18,7 @@ package net.gleske.jervis.lang
 import groovy.json.JsonSlurper
 import net.gleske.jervis.exceptions.ToolchainMissingKeyException
 import net.gleske.jervis.exceptions.ToolchainValidationException
+import net.gleske.jervis.exceptions.ToolchainBadValueInKeyException
 
 /**
   Validates the contents of a
@@ -164,11 +165,10 @@ class toolchainValidator {
             throw new ToolchainMissingKeyException('toolchains')
         }
         //check all of the toolchains inside of the toolchains key
-        (toolchains['toolchains'].keySet() as String[]).each{
-            def language = it
-            toolchains['toolchains'][it].each{
-                if(!this.supportedToolchain(it)) {
-                    throw new ToolchainMissingKeyException("toolchains.${language}.${it}.  The toolchain for ${it} is missing from the top level of the toolchains file.")
+        (toolchains['toolchains'].keySet() as String[]).each{ language ->
+            toolchains['toolchains'][language].each{ toolchain ->
+                if(!this.supportedToolchain(toolchain)) {
+                    throw new ToolchainMissingKeyException("toolchains.${language}.${toolchain}.  The toolchain for ${toolchain} is missing from the top level of the toolchains file.")
                 }
             }
         }
@@ -182,6 +182,12 @@ class toolchainValidator {
                 if(!(default_ivalue in toolchain_ivalue) && !('*' in toolchain_ivalue)) {
                     throw new ToolchainMissingKeyException("${toolchain_list[i]}.default_ivalue.${default_ivalue} is missing.  " +
                             "Must have one of the two following keys: ${toolchain_list[i]}.${default_ivalue} or ${toolchain_list[i]}.*.")
+                }
+            }
+            if('matrix' in toolchain_ivalue) {
+                def matrix = toolchains[toolchain_list[i]]['matrix']
+                if(!(matrix instanceof String) || !(matrix in ['disabled', 'simple', 'advanced'])) {
+                    throw new ToolchainBadValueInKeyException("${toolchain_list[i]}.matrix must be a String and must have one of three values: disabled, simple, advanced.")
                 }
             }
         }

--- a/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
+++ b/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
@@ -110,11 +110,33 @@ class toolchainValidator {
 
     /**
       Checks to see if a value is a supported toolchain based on the toolchains file.
-      @param toolchain A <tt>String</tt> which is a toolchain to look up based on the keys in the toolchains file.
-      @return     <tt>true</tt> if the toolchain is supported or <tt>false</tt> if the toolchain is not supported.  Note: it can exist as a toolchain but not be supported as a matrix builder.
+
+      @param toolchain A <tt>String</tt> which is a toolchain to look up based on the
+                       keys in the toolchains file.
+
+      @return          <tt>true</tt> if the toolchain is supported or <tt>false</tt>
+                       if the toolchain is not supported.  Note: it can exist as a
+                       toolchain but not be supported as a matrix builder.
      */
     public Boolean supportedToolchain(String toolchain) {
         toolchain in toolchain_list
+    }
+
+    /**
+      Checks to see what type a toolchain is.  This function assumes successful
+      validation and will not throw an exeption for a toolchain which does not exist.
+      If the toolchain does not exist it will return <tt>simple</tt>.
+
+      @return A <tt>String</tt> which has one of three values: <tt>advanced</tt>,
+              <tt>simple</tt>, <tt>disabled</tt>.
+     */
+    public String toolchainType(String toolchain) {
+        if(matrix in toolchains[toolchain]) {
+            toolchains[toolchain]['matrix']
+        }
+        else {
+            'simple'
+        }
     }
 
     /**
@@ -138,7 +160,7 @@ class toolchainValidator {
       @return          <tt>true</tt> if the toolchain is a matrix builder or <tt>false</tt> if the matrix build is not supported for that language.  Note: it can exist as a toolchain but not be supported as a matrix builder.
      */
     public Boolean supportedMatrix(String lang, String toolchain) {
-        toolchain in toolchains['toolchains'][lang]
+        (toolchain in toolchains['toolchains'][lang]) && (toolchains[toolchain]['matrix'] != 'disabled')
     }
 
     /**
@@ -164,6 +186,10 @@ class toolchainValidator {
         if(!this.supportedToolchain('toolchains')) {
             throw new ToolchainMissingKeyException('toolchains')
         }
+        //check for deprecated "advanced" env missing the matrix key in toolchains.json
+        if(('env' in toolchains) && !('matrix' in toolchains['env'])) {
+            throw new ToolchainMissingKeyException('env.matrix; env must be updated to include a "matrix: advanced" key.')
+        }
         //check all of the toolchains inside of the toolchains key
         (toolchains['toolchains'].keySet() as String[]).each{ language ->
             toolchains['toolchains'][language].each{ toolchain ->
@@ -172,7 +198,7 @@ class toolchainValidator {
                 }
             }
         }
-        for(int i=0; i<toolchain_list.size(); i++){
+        for(int i=0; i<toolchain_list.size(); i++) {
             if('toolchains' == toolchain_list[i]) {
                 continue
             }

--- a/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
+++ b/src/main/groovy/net/gleske/jervis/lang/toolchainValidator.groovy
@@ -131,7 +131,7 @@ class toolchainValidator {
               <tt>simple</tt>, <tt>disabled</tt>.
      */
     public String toolchainType(String toolchain) {
-        if(matrix in toolchains[toolchain]) {
+        if('matrix' in toolchains[toolchain]) {
             toolchains[toolchain]['matrix']
         }
         else {

--- a/src/main/resources/toolchains.json
+++ b/src/main/resources/toolchains.json
@@ -23,7 +23,7 @@
         ]
     },
     "env": {
-        "secureSupport": true,
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]

--- a/src/test/groovy/net/gleske/jervis/lang/lifecycleGeneratorTest.groovy
+++ b/src/test/groovy/net/gleske/jervis/lang/lifecycleGeneratorTest.groovy
@@ -292,6 +292,8 @@ class lifecycleGeneratorTest extends GroovyTestCase {
         //testing env global value for non-matrix configuration
         generator.loadYamlString('language: ruby\nenv:\n  global: foo=bar')
         assert '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#gemfile toolchain section\nexport BUNDLE_GEMFILE="${PWD}/Gemfile"\n#env toolchain section\nexport foo=bar\n#rvm toolchain section\nsome commands\n#jdk toolchain section\nsome commands\n' == generator.generateToolchainSection()
+        generator.loadYamlString('language: ruby\nenv:\n  global:\n    - foo=bar\n    - hello=world')
+        assert '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#gemfile toolchain section\nexport BUNDLE_GEMFILE="${PWD}/Gemfile"\n#env toolchain section\nexport foo=bar\nexport hello=world\n#rvm toolchain section\nsome commands\n#jdk toolchain section\nsome commands\n' == generator.generateToolchainSection()
         generator.loadYamlString('language: ruby\nenv:\n  global: [foo=bar]')
         assert '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#gemfile toolchain section\nexport BUNDLE_GEMFILE="${PWD}/Gemfile"\n#env toolchain section\nexport foo=bar\n#rvm toolchain section\nsome commands\n#jdk toolchain section\nsome commands\n' == generator.generateToolchainSection()
         //testing for env global throwing an exception for non-matrix configuration
@@ -531,5 +533,50 @@ class lifecycleGeneratorTest extends GroovyTestCase {
         generator.loadYamlString('language: java\njdk:')
         generator.generateAll()
         assert '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#env toolchain section\n#jdk toolchain section\nsome commands\n'.equals(generator.generateToolchainSection())
+    }
+    @Test public void test_lifecycleGenerator_isInstanceFromList() {
+        assert true == generator.isInstanceFromList("hello", [Number, String, List])
+        assert true == generator.isInstanceFromList(3.5, [Number, String, List])
+        assert true == generator.isInstanceFromList(3, [Number, String, List])
+        assert true == generator.isInstanceFromList(['a', 'b'], [Number, String, List])
+        assert false == generator.isInstanceFromList([:], [Number, String, List])
+        assert true == generator.isInstanceFromList([:], [Number, String, Map])
+    }
+    @Test public void test_lifecycleGenerator_good_toolchains_disabled_env() {
+        URL url = this.getClass().getResource('/good_toolchains_disabled_env.json');
+        generator.loadToolchains(url.getFile())
+        generator.loadYamlString('language: ruby\nenv:\n  - foo=bar\n  - hello=world')
+        assert 'disabled' == generator.toolchain_obj.toolchainType('env')
+        assert '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#gemfile toolchain section\nexport BUNDLE_GEMFILE="${PWD}/Gemfile"\n#env toolchain section\nexport foo=bar\nexport hello=world\n#rvm toolchain section\nsome commands\n#jdk toolchain section\nsome commands\n' == generator.generateToolchainSection()
+    }
+    @Test public void test_lifecycleGenerator_good_lifecycles_python_number() {
+        URL url = this.getClass().getResource('/good_lifecycles_python_number.json');
+        generator.loadLifecycles(url.getFile())
+        String compare_string = '#\n# TOOLCHAINS SECTION\n#\nset +x\necho \'# TOOLCHAINS SECTION\'\nset -x\n#env toolchain section\n#python toolchain section\nsome commands\n'
+        generator.loadYamlString('language: python\npython: 2.7')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  - 2.7')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython: "2.7"')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  - "2.7"')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  global: 2.7')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  global:\n    - 2.7')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  matrix: 2.7')
+        assert compare_string == generator.generateToolchainSection()
+        generator.loadYamlString('language: python\npython:\n  matrix:\n    - 2.7')
+        assert compare_string == generator.generateToolchainSection()
+    }
+    @Test public void test_lifecycleGenerator_bad_advanced_toolchain_when_not_supported() {
+        URL url = this.getClass().getResource('/good_toolchains_disabled_env.json');
+        generator.loadToolchains(url.getFile())
+        generator.loadYamlString('language: ruby\nenv:\n  global:\n    - foo=bar\n    - hello=world')
+        assert 'disabled' == generator.toolchain_obj.toolchainType('env')
+        shouldFail(UnsupportedToolException) {
+            generator.generateToolchainSection()
+        }
     }
 }

--- a/src/test/groovy/net/gleske/jervis/lang/lifecycleGeneratorTest.groovy
+++ b/src/test/groovy/net/gleske/jervis/lang/lifecycleGeneratorTest.groovy
@@ -363,7 +363,7 @@ class lifecycleGeneratorTest extends GroovyTestCase {
         generator.loadLifecycles(url.getFile())
         url = this.getClass().getResource('/toolchains.json');
         generator.loadToolchains(url.getFile())
-        List skip_keys = ['default_ivalue', 'secureSupport', 'friendlyLabel', 'comment']
+        List skip_keys = ['default_ivalue', 'secureSupport', 'friendlyLabel', 'comment', 'matrix']
         //cycle through all permutations of the toolchains file and check bash syntax
         generator.toolchain_obj.languages.each {
             String language = it

--- a/src/test/groovy/net/gleske/jervis/lang/toolchainValidatorTest.groovy
+++ b/src/test/groovy/net/gleske/jervis/lang/toolchainValidatorTest.groovy
@@ -15,6 +15,7 @@
    */
 package net.gleske.jervis.lang
 //the toolchainValidatorTest() class automatically sees the lifecycleValidator() class because they're in the same package
+import net.gleske.jervis.exceptions.ToolchainBadValueInKeyException
 import net.gleske.jervis.exceptions.ToolchainMissingKeyException
 import org.junit.After
 import org.junit.Before
@@ -172,5 +173,29 @@ class toolchainValidatorTest extends GroovyTestCase {
         toolchains.load_JSON(url.getFile())
         assert false == toolchains.isFriendlyLabel('env')
         assert true == toolchains.isFriendlyLabel('rvm')
+    }
+    @Test public void test_toolchainValidator_formerly_good_toolchains_simple() {
+        //this test is for migrations from jervis-0.9 to 0.10 because advanced matrices were introduced
+        URL url = this.getClass().getResource('/bad_toolchains_formerly_good_toolchains_simple.json');
+        toolchains.load_JSON(url.getFile())
+        shouldFail(ToolchainMissingKeyException) {
+            toolchains.validate()
+        }
+        assert false == toolchains.validate_asBool()
+    }
+    @Test public void test_toolchainValidator_toolchainType() {
+        URL url = this.getClass().getResource('/good_toolchains_simple.json');
+        toolchains.load_JSON(url.getFile())
+        assert 'advanced' == toolchains.toolchainType('env')
+        assert 'simple' == toolchains.toolchainType('jdk')
+        assert 'simple' == toolchains.toolchainType('foo')
+    }
+    @Test public void test_toolchainValidator_bad_toolchains_matrix_value() {
+        URL url = this.getClass().getResource('/bad_toolchains_matrix_value.json');
+        toolchains.load_JSON(url.getFile())
+        shouldFail(ToolchainBadValueInKeyException) {
+            toolchains.validate()
+        }
+        assert false == toolchains.validate_asBool()
     }
 }

--- a/src/test/resources/bad_toolchains_formerly_good_toolchains_simple.json
+++ b/src/test/resources/bad_toolchains_formerly_good_toolchains_simple.json
@@ -1,11 +1,9 @@
 {
     "toolchains": {
         "java": ["env", "jdk"],
-        "python": ["env", "python"],
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
-        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]
@@ -23,16 +21,6 @@
         ],
         "openjdk7": [
             "some commands"
-        ]
-    },
-    "python": {
-        "default_ivalue": "2.7",
-        "matrix": "advanced",
-        "2.6": [
-          "more commands"
-        ],
-        "2.7": [
-          "some commands"
         ]
     },
     "rvm": {

--- a/src/test/resources/bad_toolchains_matrix_value.json
+++ b/src/test/resources/bad_toolchains_matrix_value.json
@@ -1,11 +1,10 @@
 {
     "toolchains": {
         "java": ["env", "jdk"],
-        "python": ["env", "python"],
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
-        "matrix": "advanced",
+        "matrix": "foo",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]
@@ -23,16 +22,6 @@
         ],
         "openjdk7": [
             "some commands"
-        ]
-    },
-    "python": {
-        "default_ivalue": "2.7",
-        "matrix": "advanced",
-        "2.6": [
-          "more commands"
-        ],
-        "2.7": [
-          "some commands"
         ]
     },
     "rvm": {

--- a/src/test/resources/bad_toolchains_missing_default_ivalue.json
+++ b/src/test/resources/bad_toolchains_missing_default_ivalue.json
@@ -3,6 +3,7 @@
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]

--- a/src/test/resources/bad_toolchains_missing_toolchain.json
+++ b/src/test/resources/bad_toolchains_missing_toolchain.json
@@ -3,6 +3,7 @@
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]

--- a/src/test/resources/bad_toolchains_missing_toolchains.json
+++ b/src/test/resources/bad_toolchains_missing_toolchains.json
@@ -1,5 +1,6 @@
 {
     "env": {
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]

--- a/src/test/resources/good_lifecycles_python_number.json
+++ b/src/test/resources/good_lifecycles_python_number.json
@@ -1,0 +1,9 @@
+{
+    "python": {
+        "friendlyName": "python",
+        "defaultKey": "setuptools",
+        "setuptools": {
+            "script": "python setup.py test"
+        }
+    }
+}

--- a/src/test/resources/good_lifecycles_simple.json
+++ b/src/test/resources/good_lifecycles_simple.json
@@ -12,11 +12,11 @@
             "fileExistsCondition": "pom.xml",
             "fallbackKey": "ant",
             "install": "mvn install -DskipTests=true",
-            "script": "mvn test",
+            "script": "mvn test"
         },
         "ant": {
             "fileExistsCondition": "build.xml",
-            "script": "ant test",
+            "script": "ant test"
         }
     },
     "ruby": {
@@ -54,11 +54,11 @@
             "fileExistsCondition": "pom.xml",
             "fallbackKey": "ant",
             "install": "mvn install -DskipTests=true",
-            "script": "mvn test",
+            "script": "mvn test"
         },
         "ant": {
             "fileExistsCondition": "build.xml",
-            "script": "ant test",
+            "script": "ant test"
         }
     }
 }

--- a/src/test/resources/good_toolchains_disabled_env.json
+++ b/src/test/resources/good_toolchains_disabled_env.json
@@ -1,11 +1,10 @@
 {
     "toolchains": {
         "java": ["env", "jdk"],
-        "python": ["env", "python"],
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
-        "matrix": "advanced",
+        "matrix": "disabled",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]
@@ -23,16 +22,6 @@
         ],
         "openjdk7": [
             "some commands"
-        ]
-    },
-    "python": {
-        "default_ivalue": "2.7",
-        "matrix": "advanced",
-        "2.6": [
-          "more commands"
-        ],
-        "2.7": [
-          "some commands"
         ]
     },
     "rvm": {

--- a/src/test/resources/good_toolchains_friendly.json
+++ b/src/test/resources/good_toolchains_friendly.json
@@ -4,6 +4,7 @@
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]

--- a/src/test/resources/good_toolchains_simple.json
+++ b/src/test/resources/good_toolchains_simple.json
@@ -4,6 +4,7 @@
         "ruby": ["gemfile", "env", "rvm", "jdk"]
     },
     "env": {
+        "matrix": "advanced",
         "*": [
             "export ${jervis_toolchain_ivalue}"
         ]


### PR DESCRIPTION
Now supporting `advanced` matrices and `disabled` matrices.  The original behavior is what is now categorized as a `simple` matrix.

As a migration from 0.9 to 0.10 validation will now throw an exception if the `env` in a toolchains file does not include a `matrix` key.  This simplifies logic going forward.

Bugfix for when a user does not quote their YAML when using a number for a toolchain.  e.g.

```yaml
language: python
python: 2.7
```

or

```yaml
language: python
python:
  - 2.6
  - 2.7
```

* fixes #85
* fixes #84